### PR TITLE
ui-002: changed rgba values to hex

### DIFF
--- a/src/uistash.css
+++ b/src/uistash.css
@@ -52,8 +52,8 @@
   height: 88px;
   border-radius: 50%;
   margin: var(--margin);
-  box-shadow: rgba(0, 0, 0, 0.4) 0px 2px 4px,
-    rgba(0, 0, 0, 0.3) 0px 7px 13px -3px, rgba(0, 0, 0, 0.2) 0px -3px 0px inset;
+  box-shadow: #00000066 0px 2px 4px,
+  #0000004d 0px 7px 13px -3px,  #00000033 0px -3px 0px inset;
 }
 .avatar--letter {
   background-color: var(--primary-color);


### PR DESCRIPTION
<img width="605" alt="Screenshot 2021-11-28 at 11 50 47 PM" src="https://user-images.githubusercontent.com/74835693/143780920-41f868fc-08cb-4828-981d-cc11501011aa.png">

This PR aims at maintaining the hex code color throughout the codebase as mentioned in #2 .

<img width="421" alt="Screenshot 2021-11-28 at 11 50 35 PM" src="https://user-images.githubusercontent.com/74835693/143780954-6f144fda-7e37-4cae-a59f-9c4ba8ade65c.png">

The changes made have been tested and the box-shadow works well after the conversion.

